### PR TITLE
removed pry-byebug from seed file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 require 'nokogiri'
 require 'json'
 require "open-uri"
-require 'pry-byebug'
+# require 'pry-byebug'
 
 
 def seed_ships


### PR DESCRIPTION
## Why

This pull request is needed because:

Heroku deployment failed


## What

This pull request introduces the following:

`removed/commented out pry-byebug from seed file`
